### PR TITLE
fix: size of header image

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,7 +32,7 @@ useHead({
             </div>
         </div>
         <div class="w-full flex items-center justify-center lg:justify-end mt-10 lg:mt-0">
-            <img class="w-full lg:w-10/12 xl:w-3/5 2xl:w-1/2 max-w-[600px] mb-10 lg:mb-0" src="/assets/mosaique.png" alt="Mosaic">
+            <img class="w-full lg:w-10/12 xl:w-4/5 2xl:w-2/3 mb-10 lg:mb-0" src="/assets/mosaique.png" alt="Mosaic">
         </div>
     </main>
 </template>


### PR DESCRIPTION
This pull request includes a small change to the `pages/index.vue` file. The change adjusts the width classes for the image element to better fit different screen sizes.

Changes to image styling:

* [`pages/index.vue`](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfL35-R35): Modified the width classes for the image element to improve responsiveness.